### PR TITLE
Zabbix 7.4 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # TopHostMonzphere
+
+## Adding Top Host widget sort by value functionality
+## Check out our website [Monzphere](monzphere.com) and follow us on LinkedIn
+
+![image](https://github.com/user-attachments/assets/3d49275d-d099-4fb0-a561-e53a4013a63a)
+
+## Enable Module in Zabbix:
+
+- Go to Modules configuration:
+
+![image](https://github.com/user-attachments/assets/14353e7c-d48a-41ae-a556-2723ab61cfa2)
+
+- Click to Scan:
+
+ ![image](https://github.com/user-attachments/assets/c8b3e5ac-6381-4ffe-8e61-f61e35142d0b)
+
+- Enable module
+
+  ## Use Widget into Dashboard:
+
+![image](https://github.com/user-attachments/assets/c3adec02-ce77-4ba1-b5ff-27120fedb61d)
+
+
+
+
+
+

--- a/Widget.php
+++ b/Widget.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere;
+
+use Zabbix\Core\CWidget;
+
+class Widget extends CWidget {
+
+	public const DEFAULT_FILL = '#97AAB3';
+
+	public const ORDER_TOP_N = 2;
+	public const ORDER_BOTTOM_N = 3;
+
+	public const TEXT_MAX_LENGTH = 20;
+
+	public const DEFAULT_COLOR_PALETTE = [
+		'E65660', 'FCCB1D', '3BC97D', '2ED3B7', '19D0D7', '29C2FA', '58B0FE', '5D98FE', '859AFA', 'E580FA',
+		'F773C7', 'FC5F7E', 'FC738E', 'FF6D2E', 'F48D48', 'F89C3A', 'FBB318', 'FECF62', '87CE40', 'A3E86D'
+	];
+
+	public function getDefaultName(): string {
+		return _('Top hosts Monzphere');
+	}
+
+	public function getTranslationStrings(): array {
+		return [
+			'class.widget.js' => [
+				'Empty value.' => _('Empty value.'),
+				'Image loading error.' => _('Image loading error.')
+			]
+		];
+	}
+}

--- a/actions/ColumnEditMonzphere.php
+++ b/actions/ColumnEditMonzphere.php
@@ -1,0 +1,216 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere\Actions;
+
+use CController,
+	CControllerResponseData,
+	CNumberParser,
+	CParser,
+	CWidgetsData;
+
+use Zabbix\Widgets\CWidgetField;
+use Zabbix\Widgets\Fields\CWidgetFieldTimePeriod;
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+use Modules\TopHostsMonzphere\Widget;
+
+class ColumnEditMonzphere extends CController {
+
+	protected function init(): void {
+		$this->disableCsrfValidation();
+	}
+
+	protected function checkInput(): bool {
+		// Validation is done by CWidgetFieldColumnsList
+		$fields = [
+			'name' =>				'string',
+			'data' =>				'int32',
+			'item' =>				'string',
+			'display_value_as' =>	'int32',
+			'show_thumbnail' =>		'int32',
+			'aggregate_function' =>	'int32',
+			'time_period' =>		'array',
+			'display' =>			'int32',
+			'history' =>			'int32',
+			'min' =>				'string',
+			'max' =>				'string',
+			'decimal_places' =>		'string',
+			'base_color' =>			'string',
+			'thresholds' =>			'array',
+			'highlights' =>			'array',
+			'sparkline' =>			'array',
+			'text' =>				'string',
+			'edit' =>				'in 1',
+			'update' =>				'in 1',
+			'templateid' =>			'string'
+		];
+
+		$ret = $this->validateInput($fields) && $this->validateFields();
+
+		if (!$ret) {
+			$this->setResponse(
+				(new CControllerResponseData(['main_block' => json_encode([
+					'error' => [
+						'messages' => array_column(get_and_clear_messages(), 'message')
+					]
+				], JSON_THROW_ON_ERROR)]))->disableView()
+			);
+		}
+
+		return $ret;
+	}
+
+	protected function validateFields(): bool {
+		if (!$this->hasInput('update')) {
+			return true;
+		}
+
+		$input = $this->getInputAll();
+
+		$field = new CWidgetFieldColumnsList('columns', '');
+
+		if (!$this->hasInput('edit') && !$this->hasInput('update')) {
+			$input += self::getColumnDefaults();
+		}
+
+		unset($input['edit'], $input['update'], $input['templateid']);
+		$field->setValue([$input]);
+
+		$errors = $field->validate(true);
+		array_map('error', $errors);
+
+		return !$errors;
+	}
+
+	protected function checkPermissions(): bool {
+		return $this->getUserType() >= USER_TYPE_ZABBIX_USER;
+	}
+
+	protected function doAction(): void {
+		$input = $this->getInputAll();
+		unset($input['update']);
+
+		if (!$this->hasInput('update')) {
+			$data = [
+				'action' => $this->getAction(),
+				'thresholds_colors' => Widget::DEFAULT_COLOR_PALETTE,
+				'templateid' => $this->hasInput('templateid') ? $this->getInput('templateid') : null,
+				'errors' => hasErrorMessages() ? getMessages() : null,
+				'user' => [
+					'debug_mode' => $this->getDebugMode()
+				]
+			] + $input + self::getColumnDefaults();
+
+			$data['time_period_field'] = (new CWidgetFieldTimePeriod('time_period', _('Time period')))
+				->setDefaultPeriod(['from' => 'now-1h', 'to' => 'now'])
+				->setInType(CWidgetsData::DATA_TYPE_TIME_PERIOD)
+				->acceptDashboard()
+				->acceptWidget()
+				->setFlags(CWidgetField::FLAG_NOT_EMPTY | CWidgetField::FLAG_LABEL_ASTERISK);
+
+			$data['time_period_field']->setValue($data['time_period']);
+
+			$this->setResponse(new CControllerResponseData($data));
+
+			return;
+		}
+
+		$number_parser = new CNumberParser(['with_size_suffix' => true, 'with_time_suffix' => true]);
+
+		$thresholds = [];
+
+		if (array_key_exists('thresholds', $input)) {
+			foreach ($input['thresholds'] as $threshold) {
+				$order_threshold = trim($threshold['threshold']);
+
+				if ($order_threshold !== '' && $number_parser->parse($order_threshold) == CParser::PARSE_SUCCESS) {
+					$thresholds[] = $threshold + ['order_threshold' => $number_parser->calcValue()];
+				}
+			}
+
+			unset($input['thresholds']);
+		}
+
+		if ($thresholds) {
+			uasort($thresholds,
+				static function (array $threshold_1, array $threshold_2): int {
+					return $threshold_1['order_threshold'] <=> $threshold_2['order_threshold'];
+				}
+			);
+
+			$input['thresholds'] = [];
+
+			foreach ($thresholds as $threshold) {
+				unset($threshold['order_threshold']);
+
+				$input['thresholds'][] = $threshold;
+			}
+		}
+
+		// Process highlights
+		if (array_key_exists('highlights', $input)) {
+			$highlights = [];
+			foreach ($input['highlights'] as $highlight) {
+				if (trim($highlight['pattern']) !== '') {
+					$highlights[] = $highlight;
+				}
+			}
+			$input['highlights'] = $highlights;
+		}
+
+		$this->setResponse(
+			(new CControllerResponseData(['main_block' => json_encode($input, JSON_THROW_ON_ERROR)]))->disableView()
+		);
+	}
+
+	/**
+	 * Retrieve the default configuration values for column in Top hosts widget.
+	 *
+	 * @return array
+	 */
+	private static function getColumnDefaults(): array {
+		static $column_defaults;
+
+		if ($column_defaults === null) {
+			$column_defaults = [
+				'name' => '',
+				'data' => CWidgetFieldColumnsList::DATA_ITEM_VALUE,
+				'item' => '',
+				'display_value_as' => CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC,
+				'show_thumbnail' => 0,
+				'aggregate_function' => AGGREGATE_NONE,
+				'time_period' => [
+					CWidgetField::FOREIGN_REFERENCE_KEY => CWidgetField::createTypedReference(
+						CWidgetField::REFERENCE_DASHBOARD, CWidgetsData::DATA_TYPE_TIME_PERIOD
+					)
+				],
+				'display' => CWidgetFieldColumnsList::DISPLAY_AS_IS,
+				'history' => CWidgetFieldColumnsList::HISTORY_DATA_AUTO,
+				'min' => '',
+				'max' => '',
+				'decimal_places' => CWidgetFieldColumnsList::DEFAULT_DECIMAL_PLACES,
+				'base_color' => '',
+				'text' => '',
+				'thresholds' => [],
+				'highlights' => [],
+				'sparkline' => []
+			];
+		}
+
+		return $column_defaults;
+	}
+}

--- a/actions/WidgetViewMonzphere.php
+++ b/actions/WidgetViewMonzphere.php
@@ -1,0 +1,517 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere\Actions;
+
+use API,
+	CAggFunctionData,
+	CArrayHelper,
+	CControllerDashboardWidgetView,
+	CControllerResponseData,
+	CItemHelper,
+	CMacrosResolverHelper,
+	CNumberParser,
+	CSettingsHelper,
+	Manager;
+
+use Modules\TopHostsMonzphere\Widget;
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+
+class WidgetViewMonzphere extends CControllerDashboardWidgetView {
+
+	protected function doAction(): void {
+		$data = [
+			'name' => $this->getInput('name', $this->widget->getDefaultName()),
+			'user' => [
+				'debug_mode' => $this->getDebugMode()
+			]
+		];
+
+		// Editing template dashboard?
+		if ($this->isTemplateDashboard() && !$this->fields_values['override_hostid']) {
+			$data['error'] = _('No data.');
+		}
+		else {
+			$data += $this->getData();
+			$data['error'] = null;
+		}
+
+		$this->setResponse(new CControllerResponseData($data));
+	}
+
+	private function getData(): array {
+		$configuration = $this->fields_values['columns'];
+
+		$groupids = !$this->isTemplateDashboard() && $this->fields_values['groupids']
+			? getSubGroups($this->fields_values['groupids'])
+			: null;
+
+		if ($this->isTemplateDashboard()) {
+			$hostids = $this->fields_values['override_hostid'];
+		}
+		else {
+			$hostids = $this->fields_values['hostids'] ?: null;
+		}
+
+		$tags_exist = array_key_exists('tags', $this->fields_values);
+		$maintenance_status = $this->fields_values['maintenance'] == HOST_MAINTENANCE_STATUS_OFF
+			? HOST_MAINTENANCE_STATUS_OFF
+			: null;
+
+		$hosts = API::Host()->get([
+			'output' => ['name', 'maintenance_status', 'maintenanceid'],
+			'groupids' => $groupids,
+			'hostids' => $hostids,
+			'evaltype' => $tags_exist ? $this->fields_values['evaltype'] : null,
+			'tags' => $tags_exist ? $this->fields_values['tags'] : null,
+			'filter' => ['maintenance_status' => $maintenance_status],
+			'monitored_hosts' => true,
+			'preservekeys' => true
+		]);
+
+		$hostids = array_keys($hosts);
+		$maintenanceids = array_filter(array_column($hosts, 'maintenanceid', 'maintenanceid'));
+
+		$db_maintenances = $maintenanceids && $maintenance_status === null
+			? API::Maintenance()->get([
+				'output' => ['name', 'maintenance_type', 'description'],
+				'maintenanceids' => $maintenanceids,
+				'preservekeys' => true
+			])
+			: [];
+
+		$db_maintenances = CArrayHelper::renameObjectsKeys($db_maintenances,
+			['name' => 'maintenance_name', 'description' => 'maintenance_description']
+		);
+
+		$has_text_column = false;
+		$item_names = [];
+		$items = [];
+
+		foreach ($configuration as $column_index => $column) {
+			switch ($column['data']) {
+				case CWidgetFieldColumnsList::DATA_TEXT:
+					$has_text_column = true;
+					break 2;
+
+				case CWidgetFieldColumnsList::DATA_ITEM_VALUE:
+					$item_names[$column_index] = $column['item'];
+					break;
+			}
+		}
+
+		if (!$has_text_column && $item_names) {
+			$hosts_with_items = [];
+
+			foreach ($item_names as $column_index => $item_name) {
+				$numeric_only = self::isNumericOnlyColumn($configuration[$column_index]);
+				$items[$column_index] = self::getItems($item_name, $numeric_only, $groupids, $hostids);
+
+				foreach ($items[$column_index] as $item) {
+					$hosts_with_items[$item['hostid']] = true;
+				}
+			}
+
+			$hostids = array_keys($hosts_with_items);
+			$hosts = array_intersect_key($hosts, $hosts_with_items);
+		}
+
+		if (!$hostids) {
+			return [
+				'configuration' => $configuration,
+				'rows' => []
+			];
+		}
+
+		$master_column_index = $this->fields_values['column'];
+		$master_column = $configuration[$master_column_index];
+		$master_entities = $hosts;
+		$master_entity_values = [];
+
+		switch ($master_column['data']) {
+			case CWidgetFieldColumnsList::DATA_ITEM_VALUE:
+				$master_entities = array_key_exists($master_column_index, $items)
+					? $items[$master_column_index]
+					: self::getItems($master_column['item'], self::isNumericOnlyColumn($master_column), $groupids,
+						$hostids
+					);
+				$master_entity_values = self::getItemValues($master_entities, $master_column);
+				break;
+
+			case CWidgetFieldColumnsList::DATA_HOST_NAME:
+				$master_entity_values = array_column($master_entities, 'name', 'hostid');
+				break;
+
+			case CWidgetFieldColumnsList::DATA_TEXT:
+				$master_entity_values = CMacrosResolverHelper::resolveWidgetTopHostsTextColumns(
+					[$master_column_index => $master_column['text']], $hostids
+				)[$master_column_index];
+
+				foreach ($master_entity_values as $key => $value) {
+					if ($value === '') {
+						unset($master_entity_values[$key], $master_entities[$key]);
+					}
+				}
+
+				break;
+		}
+
+		$master_items_only_numeric_present = $master_column['data'] == CWidgetFieldColumnsList::DATA_ITEM_VALUE
+			&& ($master_column['aggregate_function'] == AGGREGATE_COUNT
+				|| !array_filter($master_entities,
+					static function(array $item): bool {
+						return !in_array($item['value_type'], [ITEM_VALUE_TYPE_FLOAT, ITEM_VALUE_TYPE_UINT64]);
+					}
+				)
+			);
+
+		if ($this->fields_values['order'] == Widget::ORDER_TOP_N) {
+			if ($master_items_only_numeric_present) {
+				arsort($master_entity_values, SORT_NUMERIC);
+
+				$master_entities_min = end($master_entity_values);
+				$master_entities_max = reset($master_entity_values);
+			}
+			else {
+				natcasesort($master_entity_values);
+			}
+		}
+		else {
+			if ($master_items_only_numeric_present) {
+				asort($master_entity_values, SORT_NUMERIC);
+
+				$master_entities_min = reset($master_entity_values);
+				$master_entities_max = end($master_entity_values);
+			}
+			else {
+				natcasesort($master_entity_values);
+				$master_entity_values = array_reverse($master_entity_values, true);
+			}
+		}
+
+		$show_lines = $this->isTemplateDashboard() ? 1 : $this->fields_values['show_lines'];
+		$master_entity_values = array_slice($master_entity_values, 0, $show_lines, true);
+		$master_entities = array_intersect_key($master_entities, $master_entity_values);
+
+		$master_hostids = [];
+
+		foreach (array_keys($master_entity_values) as $entity) {
+			$master_hostids[$master_entities[$entity]['hostid']] = true;
+		}
+
+		if (count($master_hostids) < $show_lines) {
+			foreach ($hostids as $hostid) {
+				if (!array_key_exists($hostid, $master_hostids)) {
+					$master_hostids[$hostid] = true;
+				}
+
+				if (count($master_hostids) == $show_lines) {
+					break;
+				}
+			}
+		}
+
+		$master_hostids = array_keys($master_hostids);
+
+		$number_parser = new CNumberParser([
+			'with_size_suffix' => true,
+			'with_time_suffix' => true,
+			'is_binary_size' => false
+		]);
+
+		$number_parser_binary = new CNumberParser([
+			'with_size_suffix' => true,
+			'with_time_suffix' => true,
+			'is_binary_size' => true
+		]);
+
+		$item_values = [];
+		$text_columns = [];
+
+		foreach ($configuration as $column_index => &$column) {
+			if ($column['data'] == CWidgetFieldColumnsList::DATA_TEXT) {
+				$text_columns[$column_index] = $column['text'];
+				continue;
+			}
+
+			if ($column['data'] != CWidgetFieldColumnsList::DATA_ITEM_VALUE) {
+				continue;
+			}
+
+			$calc_extremes = $column['display'] == CWidgetFieldColumnsList::DISPLAY_BAR
+				|| $column['display'] == CWidgetFieldColumnsList::DISPLAY_INDICATORS;
+
+			if ($column_index == $master_column_index) {
+				$column_items = $master_entities;
+				$column_item_values = $master_entity_values;
+			}
+			else {
+				$numeric_only = self::isNumericOnlyColumn($column);
+
+				if (!$calc_extremes || ($column['min'] !== '' && $column['max'] !== '')) {
+					$column_items = self::getItems($column['item'], $numeric_only, $groupids, $master_hostids);
+				}
+				else {
+					$column_items = array_key_exists($column_index, $items)
+						? $items[$column_index]
+						: self::getItems($column['item'], $numeric_only, $groupids, $hostids);
+				}
+
+				$column_item_values = self::getItemValues($column_items, $column);
+			}
+
+			if ($calc_extremes && ($column['min'] !== '' || $column['max'] !== '')) {
+				if ($column['min'] !== '') {
+					$number_parser_binary->parse($column['min']);
+					$column['min_binary'] = $number_parser_binary->calcValue();
+
+					$number_parser->parse($column['min']);
+					$column['min'] = $number_parser->calcValue();
+				}
+
+				if ($column['max'] !== '') {
+					$number_parser_binary->parse($column['max']);
+					$column['max_binary'] = $number_parser_binary->calcValue();
+
+					$number_parser->parse($column['max']);
+					$column['max'] = $number_parser->calcValue();
+				}
+			}
+
+			if (array_key_exists('thresholds', $column)) {
+				foreach ($column['thresholds'] as &$threshold) {
+					$number_parser_binary->parse($threshold['threshold']);
+					$threshold['threshold_binary'] = $number_parser_binary->calcValue();
+
+					$number_parser->parse($threshold['threshold']);
+					$threshold['threshold'] = $number_parser->calcValue();
+				}
+				unset($threshold);
+			}
+
+			if ($column_index == $master_column_index) {
+				if ($calc_extremes) {
+					if ($column['min'] === '') {
+						$column['min'] = $master_entities_min;
+						$column['min_binary'] = $column['min'];
+					}
+
+					if ($column['max'] === '') {
+						$column['max'] = $master_entities_max;
+						$column['max_binary'] = $column['max'];
+					}
+				}
+			}
+			else {
+				if ($calc_extremes && $column_item_values) {
+					if ($column['min'] === '') {
+						$column['min'] = min($column_item_values);
+						$column['min_binary'] = $column['min'];
+					}
+
+					if ($column['max'] === '') {
+						$column['max'] = max($column_item_values);
+						$column['max_binary'] = $column['max'];
+					}
+				}
+			}
+
+			$item_values[$column_index] = [];
+
+			foreach ($column_item_values as $itemid => $column_item_value) {
+				if (in_array($column_items[$itemid]['hostid'], $master_hostids)) {
+					$item_values[$column_index][$column_items[$itemid]['hostid']] = [
+						'value' => $column_item_value,
+						'item' => $column_items[$itemid],
+						'is_binary_units' => isBinaryUnits($column_items[$itemid]['units'])
+					];
+				}
+			}
+		}
+		unset($column);
+
+		$text_columns = CMacrosResolverHelper::resolveWidgetTopHostsTextColumns($text_columns, $master_hostids);
+
+		$rows = [];
+
+		foreach ($master_hostids as $hostid) {
+			$row = [];
+
+			foreach ($configuration as $column_index => $column) {
+				switch ($column['data']) {
+					case CWidgetFieldColumnsList::DATA_HOST_NAME:
+						$data = [
+							'value' => $hosts[$hostid]['name'],
+							'hostid' => $hostid,
+							'maintenance_status' => $hosts[$hostid]['maintenance_status']
+						];
+
+						if ($data['maintenance_status'] == HOST_MAINTENANCE_STATUS_ON) {
+							$data = array_merge($data, $db_maintenances[$hosts[$hostid]['maintenanceid']]);
+						}
+
+						$row[] = $data;
+
+						break;
+
+					case CWidgetFieldColumnsList::DATA_TEXT:
+						$row[] = ['value' => $text_columns[$column_index][$hostid]];
+
+						break;
+
+					case CWidgetFieldColumnsList::DATA_ITEM_VALUE:
+						$row[] = array_key_exists($hostid, $item_values[$column_index])
+							? [
+								'value' => $item_values[$column_index][$hostid]['value'],
+								'item' => $item_values[$column_index][$hostid]['item'],
+								'is_binary_units' => $item_values[$column_index][$hostid]['is_binary_units']
+							]
+							: null;
+
+						break;
+				}
+			}
+
+			$rows[] = [
+				'columns' => $row,
+				'context' => ['hostid' => $hostid]
+			];
+		}
+
+		return [
+			'configuration' => $configuration,
+			'rows' => $rows
+		];
+	}
+
+	/**
+	 * Check if column configuration requires selecting numeric items only.
+	 *
+	 * @param array $column  Column configuration.
+	 *
+	 * @return bool
+	 */
+	private static function isNumericOnlyColumn(array $column): bool {
+		if ($column['display'] == CWidgetFieldColumnsList::DISPLAY_AS_IS) {
+			return CAggFunctionData::requiresNumericItem($column['aggregate_function']);
+		}
+
+		return $column['aggregate_function'] != AGGREGATE_COUNT;
+	}
+
+	private static function getItems(string $name, bool $numeric_only, ?array $groupids, ?array $hostids): array {
+		$items = API::Item()->get([
+			'output' => ['itemid', 'hostid', 'key_', 'history', 'trends', 'value_type', 'units'],
+			'selectValueMap' => ['mappings'],
+			'groupids' => $groupids,
+			'hostids' => $hostids,
+			'monitored' => true,
+			'webitems' => true,
+			'filter' => [
+				'name_resolved' => $name,
+				'status' => ITEM_STATUS_ACTIVE,
+				'value_type' => $numeric_only ? [ITEM_VALUE_TYPE_FLOAT, ITEM_VALUE_TYPE_UINT64] : null
+			],
+			'sortfield' => 'key_',
+			'preservekeys' => true
+		]);
+
+		if ($items) {
+			$processed_hostids = [];
+
+			$items = array_filter($items, static function ($item) use (&$processed_hostids) {
+				if (array_key_exists($item['hostid'], $processed_hostids)) {
+					return false;
+				}
+
+				$processed_hostids[$item['hostid']] = true;
+
+				return true;
+			});
+		}
+
+		return $items;
+	}
+
+	private static function getItemValues(array $items, array $column): array {
+		static $history_period_s;
+
+		if ($history_period_s === null) {
+			$history_period_s = timeUnitToSeconds(CSettingsHelper::get(CSettingsHelper::HISTORY_PERIOD));
+		}
+
+		$time_from = $column['aggregate_function'] != AGGREGATE_NONE
+			? $column['time_period']['from_ts']
+			: time() - $history_period_s;
+
+		$items = self::addDataSource($items, $time_from, $column);
+
+		$result = [];
+
+		if ($column['aggregate_function'] != AGGREGATE_NONE) {
+			$values = Manager::History()->getAggregatedValues($items, $column['aggregate_function'], $time_from,
+				$column['time_period']['to_ts']
+			);
+
+			$result += array_column($values, 'value', 'itemid');
+		}
+		else {
+			$items_by_source = ['history' => [], 'trends' => []];
+
+			foreach (self::addDataSource($items, $time_from, $column) as $itemid => $item) {
+				$items_by_source[$item['source']][$itemid] = $item;
+			}
+
+			if ($items_by_source['history']) {
+				$values = Manager::History()->getLastValues($items_by_source['history'], 1, $history_period_s);
+				$result += array_column(array_column($values, 0), 'value', 'itemid');
+			}
+
+			if ($items_by_source['trends']) {
+				$values = Manager::History()->getAggregatedValues($items_by_source['trends'], AGGREGATE_LAST,
+					$time_from
+				);
+
+				$result += array_column($values, 'value', 'itemid');
+			}
+		}
+
+		return $result;
+	}
+
+	private static function addDataSource(array $items, int $time, array $column): array {
+		if ($column['history'] == CWidgetFieldColumnsList::HISTORY_DATA_AUTO) {
+			$items = CItemHelper::addDataSource($items, $time);
+		}
+		else {
+			foreach ($items as &$item) {
+				$item['source'] = $column['history'] == CWidgetFieldColumnsList::HISTORY_DATA_TRENDS
+					? 'trends'
+					: 'history';
+			}
+			unset($item);
+		}
+
+		foreach ($items as &$item) {
+			if (!in_array($item['value_type'], [ITEM_VALUE_TYPE_FLOAT, ITEM_VALUE_TYPE_UINT64])) {
+				$item['source'] = 'history';
+			}
+		}
+		unset($item);
+
+		return $items;
+	}
+}

--- a/assets/css/widget.monzphere.css
+++ b/assets/css/widget.monzphere.css
@@ -1,0 +1,54 @@
+/* Force table to distribute columns evenly */
+.list-table {
+	table-layout: fixed !important;
+	width: 100% !important;
+}
+
+/* All cells should truncate long content */
+.list-table td,
+.list-table th {
+	overflow: hidden !important;
+	text-overflow: ellipsis !important;
+	white-space: nowrap !important;
+	max-width: 1px !important;
+}
+
+/* Links inside cells */
+.list-table td a,
+.list-table td .link-action {
+	display: block !important;
+	overflow: hidden !important;
+	text-overflow: ellipsis !important;
+	white-space: nowrap !important;
+}
+
+/* Sortable column headers */
+.sortable-monzphere {
+	cursor: pointer;
+	position: relative;
+	padding-right: 20px !important;
+}
+
+.sortable-monzphere:hover {
+	background-color: rgba(0, 0, 0, 0.05);
+}
+
+.sortable-monzphere::after {
+	content: '⇅';
+	position: absolute;
+	right: 8px;
+	top: 50%;
+	transform: translateY(-50%);
+	opacity: 0.5;
+	font-size: 14px;
+}
+
+.sortable-monzphere.sort-asc::after {
+	content: '↑';
+	opacity: 1;
+}
+
+.sortable-monzphere.sort-desc::after {
+	content: '↓';
+	opacity: 1;
+}

--- a/assets/js/class.widgetmonzphere.js
+++ b/assets/js/class.widgetmonzphere.js
@@ -1,0 +1,201 @@
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+class CWidgetTopHostsMonzphere extends CWidget {
+	/**
+	 * Table body of top hosts.
+	 *
+	 * @type {HTMLElement|null}
+	 */
+	#table_body = null;
+	/**
+	 * ID of selected host.
+	 *
+	 * @type {string}
+	 */
+	#selected_host_id = '';
+	#current_sort = {
+		column: null,
+		order: 'asc'
+	};
+	setContents(response) {
+		super.setContents(response);
+		this.#table_body = this._contents.querySelector(`.${ZBX_STYLE_LIST_TABLE} tbody`);
+		if (this.#table_body !== null) {
+			if (this.#selected_host_id !== '') {
+				const row = this.#table_body.querySelector(`tr[data-hostid="${this.#selected_host_id}"]`);
+				if (row !== null) {
+					this.#selectHost();
+				}
+				else {
+					this.#selected_host_id = '';
+				}
+			}
+			this.#table_body.addEventListener('click', e => this.#onTableBodyClick(e));
+			
+
+			const headers = this._contents.querySelectorAll('.sortable-monzphere');
+			headers.forEach(header => {
+				header.addEventListener('click', e => this.#onHeaderClick(e));
+			});
+		}
+	}
+	#selectHost() {
+		const rows = this.#table_body.querySelectorAll('tr[data-hostid]');
+		for (const row of rows) {
+			row.classList.toggle(ZBX_STYLE_ROW_SELECTED, row.dataset.hostid === this.#selected_host_id);
+		}
+	}
+	#onTableBodyClick(e) {
+		if (e.target.closest('a') !== null || e.target.closest('[data-hintbox="1"]') !== null) {
+			return;
+		}
+		const row = e.target.closest('tr');
+		if (row !== null) {
+			const hostid = row.dataset.hostid;
+			if (hostid !== undefined) {
+				this.#selected_host_id = hostid;
+				this.#selectHost();
+				this.broadcast({
+					[CWidgetsData.DATA_TYPE_HOST_ID]: [hostid],
+					[CWidgetsData.DATA_TYPE_HOST_IDS]: [hostid]
+				});
+			}
+		}
+	}
+	#onHeaderClick(e) {
+		const header = e.currentTarget;
+		const column = header.getAttribute('data-column');
+
+		if (this.#current_sort.column === column) {
+			this.#current_sort.order = this.#current_sort.order === 'asc' ? 'desc' : 'asc';
+		}
+		else {
+			this.#current_sort.column = column;
+			this.#current_sort.order = 'asc';
+		}
+
+		this._contents.querySelectorAll('.sortable-monzphere').forEach(h => {
+			h.classList.remove('sort-asc', 'sort-desc');
+		});
+
+		header.classList.add(`sort-${this.#current_sort.order}`);
+		this.#sortTable(column, this.#current_sort.order);
+	}
+	#sortTable(column, order) {
+		const rows = Array.from(this.#table_body.querySelectorAll('tr'));
+		
+		rows.sort((a, b) => {
+			let valueA = this.#getCellValue(a, column);
+			let valueB = this.#getCellValue(b, column);
+
+			if (valueA === '' && valueB === '') {
+				return 0;
+			}
+			if (valueA === '') {
+				return order === 'asc' ? -1 : 1;
+			}
+			if (valueB === '') {
+				return order === 'asc' ? 1 : -1;
+			}
+
+			if (!isNaN(valueA) && !isNaN(valueB)) {
+				valueA = parseFloat(valueA);
+				valueB = parseFloat(valueB);
+			}
+			
+			if (order === 'asc') {
+				return valueA > valueB ? 1 : -1;
+			}
+			else {
+				return valueA < valueB ? 1 : -1;
+			}
+		});
+
+		rows.forEach(row => this.#table_body.appendChild(row));
+	}
+	#getCellValue(row, column) {
+		const cells = row.cells;
+		const headers = this._contents.querySelectorAll('th');
+		let adjustedColumn = parseInt(column);
+		let currentColumn = 0;
+		let actualIndex = 0;
+		
+		const barGaugeColumns = new Set();
+		let headerIndex = 0;
+		
+		headers.forEach((header, index) => {
+			if (header.colSpan === 2) {
+				barGaugeColumns.add(headerIndex);
+				headerIndex += 1;
+			}
+			else {
+				headerIndex += 1;
+			}
+		});
+
+		while (currentColumn < adjustedColumn) {
+			if (barGaugeColumns.has(currentColumn)) {
+				actualIndex += 2; 
+			}
+			else {
+				actualIndex += 1;
+			}
+			currentColumn += 1;
+		}
+		
+		const cell = cells[actualIndex];
+		if (!cell) {
+			return '';
+		}
+
+
+		if (barGaugeColumns.has(adjustedColumn)) {
+			const barGauge = cell.querySelector('z-bar-gauge');
+			if (barGauge) {
+				return barGauge.getAttribute('value');
+			}
+
+			const nextCell = cells[actualIndex + 1];
+			if (nextCell) {
+				const hintbox = nextCell.querySelector('[data-hintbox]');
+				if (hintbox) {
+					const hintboxContent = hintbox.getAttribute('data-hintbox-contents');
+					if (hintboxContent) {
+						const match = hintboxContent.match(/>([\d.]+)</);
+						if (match) {
+							return match[1];
+						}
+					}
+					return hintbox.textContent;
+				}
+			}
+		}
+		else {
+
+			const hintbox = cell.querySelector('[data-hintbox]');
+			if (hintbox) {
+				const hintboxContent = hintbox.getAttribute('data-hintbox-contents');
+				if (hintboxContent) {
+					const match = hintboxContent.match(/>([\d.]+)</);
+					if (match) {
+						return match[1];
+					}
+				}
+				return hintbox.textContent;
+			}
+		}
+
+		return cell.textContent.trim();
+	}
+}

--- a/includes/CWidgetFieldColumnsList.php
+++ b/includes/CWidgetFieldColumnsList.php
@@ -1,0 +1,288 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2026 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere\Includes;
+
+use CWidgetsData;
+
+use Zabbix\Widgets\CWidgetField;
+use Zabbix\Widgets\Fields\CWidgetFieldTimePeriod;
+use Zabbix\Widgets\Fields\CWidgetFieldSparkline;
+
+class CWidgetFieldColumnsList extends CWidgetField {
+
+	public const DEFAULT_VIEW = CWidgetFieldColumnsListView::class;
+	public const DEFAULT_VALUE = [];
+
+	// Source of value to display in column.
+	public const DATA_ITEM_VALUE = 1;
+	public const DATA_HOST_NAME = 2;
+	public const DATA_TEXT = 3;
+
+	// Item value column display as type.
+	public const DISPLAY_VALUE_AS_NUMERIC = 0;
+	public const DISPLAY_VALUE_AS_TEXT = 1;
+	public const DISPLAY_VALUE_AS_BINARY = 2;
+
+	// Numeric item value display type.
+	public const DISPLAY_AS_IS = 1;
+	public const DISPLAY_BAR = 2;
+	public const DISPLAY_INDICATORS = 3;
+	public const DISPLAY_SPARKLINE = 6;
+
+	// Where to select data for aggregation function.
+	public const HISTORY_DATA_AUTO = 0;
+	public const HISTORY_DATA_HISTORY = 1;
+	public const HISTORY_DATA_TRENDS = 2;
+
+	public const DEFAULT_DECIMAL_PLACES = 2;
+
+	public const SPARKLINE_DEFAULT = [
+		'width'		=> 1,
+		'fill'		=> 3,
+		'color'		=> '42A5F5',
+		'time_period' => [
+			'data_source' => CWidgetFieldTimePeriod::DATA_SOURCE_DEFAULT,
+			'from' => 'now-1h',
+			'to' => 'now'
+		],
+		'history'	=> CWidgetFieldSparkline::DATA_SOURCE_AUTO
+	];
+
+	private array $fields_objects = [];
+
+	public function __construct(string $name, ?string $label = null) {
+		parent::__construct($name, $label);
+
+		$this->setDefault(self::DEFAULT_VALUE);
+	}
+
+	public function setValue($value): self {
+		$this->value = (array) $value;
+
+		return $this;
+	}
+
+	public function validate(bool $strict = false): array {
+		$errors = parent::validate($strict);
+
+		if ($errors) {
+			return $errors;
+		}
+
+		$this->fields_objects = [];
+
+		$columns_values = $this->getValue();
+
+		foreach ($columns_values as $column_index => &$value) {
+			if ($value['data'] != self::DATA_ITEM_VALUE) {
+				continue;
+			}
+
+			$fields = [];
+
+			if ($value['display'] == self::DISPLAY_SPARKLINE) {
+				$sparkline = (new CWidgetFieldSparkline($this->name.'.'.$column_index.'.sparkline', null,
+					['color' => ['use_default' => false]]
+				))
+					->setInType(CWidgetsData::DATA_TYPE_TIME_PERIOD)
+					->acceptDashboard()
+					->setDefault(CWidgetFieldColumnsList::SPARKLINE_DEFAULT)
+					->acceptWidget();
+
+				if (array_key_exists('sparkline', $value)) {
+					$sparkline->setValue($value['sparkline']);
+				}
+
+				$fields['sparkline'] = $sparkline;
+			}
+
+			if ($value['aggregate_function'] != AGGREGATE_NONE) {
+				$time_period_field = (new CWidgetFieldTimePeriod($this->name.'.'.$column_index.'.time_period',
+					'/'.($column_index + 1)
+				))
+					->setDefault([
+						CWidgetField::FOREIGN_REFERENCE_KEY => CWidgetField::createTypedReference(
+							CWidgetField::REFERENCE_DASHBOARD, CWidgetsData::DATA_TYPE_TIME_PERIOD
+						)
+					])
+					->setInType(CWidgetsData::DATA_TYPE_TIME_PERIOD)
+					->acceptDashboard()
+					->acceptWidget()
+					->setFlags(CWidgetField::FLAG_NOT_EMPTY | CWidgetField::FLAG_LABEL_ASTERISK);
+
+				if (array_key_exists('time_period', $value)) {
+					$time_period_field->setValue($value['time_period']);
+				}
+
+				$fields['time_period'] = $time_period_field;
+			}
+
+			foreach ($fields as $i => $field) {
+				$errors = $field->validate($strict);
+
+				if ($errors) {
+					return $errors;
+				}
+
+				$value[$i] = $field->getValue();
+
+				$this->fields_objects[] = $field;
+			}
+		}
+		unset($value);
+
+		$this->setValue($columns_values);
+
+		return [];
+	}
+
+	public function toApi(array &$widget_fields = []): void {
+		$fields = [
+			'name' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'data' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'text' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'item' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'base_color' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'display_value_as' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'display' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'min' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'max' => ZBX_WIDGET_FIELD_TYPE_STR,
+			'decimal_places' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'show_thumbnail' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'aggregate_function' => ZBX_WIDGET_FIELD_TYPE_INT32,
+			'history' => ZBX_WIDGET_FIELD_TYPE_INT32
+		];
+
+		$column_defaults = [
+			'base_color' => '',
+			'display_value_as' => CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC,
+			'display' => CWidgetFieldColumnsList::DISPLAY_AS_IS,
+			'min' => '',
+			'max' => '',
+			'decimal_places' => CWidgetFieldColumnsList::DEFAULT_DECIMAL_PLACES,
+			'show_thumbnail' => 0,
+			'aggregate_function' => AGGREGATE_NONE,
+			'history' => CWidgetFieldColumnsList::HISTORY_DATA_AUTO
+		];
+
+		foreach ($this->getValue() as $column_index => $value) {
+			foreach (array_intersect_key($fields, $value) as $field => $field_type) {
+				if (!array_key_exists($field, $column_defaults) || $column_defaults[$field] !== $value[$field]) {
+					$widget_fields[] = [
+						'type' => $field_type,
+						'name' => $this->name.'.'.$column_index.'.'.$field,
+						'value' => $value[$field]
+					];
+				}
+			}
+
+			if (array_key_exists('thresholds', $value)) {
+				foreach ($value['thresholds'] as $threshold_index => $threshold) {
+					$widget_fields[] = [
+						'type' => ZBX_WIDGET_FIELD_TYPE_STR,
+						'name' => $this->name.'thresholds.'.$column_index.'.color.'.$threshold_index,
+						'value' => $threshold['color']
+					];
+					$widget_fields[] = [
+						'type' => ZBX_WIDGET_FIELD_TYPE_STR,
+						'name' => $this->name.'thresholds.'.$column_index.'.threshold.'.$threshold_index,
+						'value' => $threshold['threshold']
+					];
+				}
+			}
+
+			if (array_key_exists('highlights', $value)) {
+				foreach ($value['highlights'] as $highlight_index => $highlight) {
+					$widget_fields[] = [
+						'type' => ZBX_WIDGET_FIELD_TYPE_STR,
+						'name' => $this->name.'.'.$column_index.'.highlights.'.$highlight_index.'.color',
+						'value' => $highlight['color']
+					];
+
+					$widget_fields[] = [
+						'type' => ZBX_WIDGET_FIELD_TYPE_STR,
+						'name' => $this->name.'.'.$column_index.'.highlights.'.$highlight_index.'.pattern',
+						'value' => $highlight['pattern']
+					];
+				}
+			}
+		}
+
+		foreach ($this->fields_objects as $field) {
+			$field->toApi($widget_fields);
+		}
+	}
+
+	protected function getValidationRules(bool $strict = false): array {
+		$validation_rules = ['type' => API_OBJECTS, 'fields' => [
+			'name'					=> ['type' => API_STRING_UTF8, 'flags' => API_REQUIRED | API_NOT_EMPTY, 'length' => 255],
+			'data'					=> ['type' => API_INT32, 'flags' => API_REQUIRED, 'in' => implode(',', [self::DATA_ITEM_VALUE, self::DATA_HOST_NAME, self::DATA_TEXT])],
+			'text'					=> ['type' => API_MULTIPLE, 'rules' => [
+										['if' => ['field' => 'data', 'in' => self::DATA_TEXT],
+											'type' => API_STRING_UTF8, 'flags' => API_REQUIRED | API_NOT_EMPTY, 'length' => 255],
+										['else' => true,
+											'type' => API_STRING_UTF8]
+			]],
+			'item'					=> ['type' => API_MULTIPLE, 'rules' => [
+											['if' => ['field' => 'data', 'in' => self::DATA_ITEM_VALUE],
+												'type' => API_STRING_UTF8, 'flags' => API_REQUIRED | API_NOT_EMPTY, 'length' => 255],
+											['else' => true,
+												'type' => API_STRING_UTF8]
+			]],
+			'base_color'			=> ['type' => API_COLOR, 'default' => ''],
+			'display_value_as'		=> ['type' => API_MULTIPLE, 'rules' => [
+										['if' => ['field' => 'data', 'in' => self::DATA_ITEM_VALUE],
+											'type' => API_INT32, 'default' => self::DISPLAY_VALUE_AS_NUMERIC, 'in' => implode(',', [self::DISPLAY_VALUE_AS_NUMERIC, self::DISPLAY_VALUE_AS_TEXT, self::DISPLAY_VALUE_AS_BINARY])],
+										['else' => true,
+											'type' => API_INT32]
+			]],
+			'display'				=> ['type' => API_MULTIPLE, 'rules' => [
+											['if' => ['field' => 'data', 'in' => self::DATA_ITEM_VALUE],
+												'type' => API_INT32, 'default' => self::DISPLAY_AS_IS, 'in' => implode(',', [self::DISPLAY_AS_IS, self::DISPLAY_BAR, self::DISPLAY_INDICATORS, self::DISPLAY_SPARKLINE])],
+											['else' => true,
+												'type' => API_INT32]
+			]],
+			'sparkline'				=> ['type' => API_ANY],
+			'min'					=> ['type' => API_NUMERIC],
+			'max'					=> ['type' => API_NUMERIC],
+			'decimal_places'		=> ['type' => API_INT32, 'in' => '0:10', 'default' => self::DEFAULT_DECIMAL_PLACES],
+			'thresholds'			=> ['type' =>  API_OBJECTS, 'uniq' => [['threshold']], 'fields' => [
+				'color'					=> ['type' => API_COLOR, 'flags' => API_REQUIRED],
+				'threshold'				=> ['type' => API_NUMERIC, 'flags' => API_REQUIRED]
+			]],
+			'highlights'			=> ['type' =>  API_OBJECTS, 'uniq' => [['pattern']], 'fields' => [
+				'color'					=> ['type' => API_COLOR, 'flags' => API_REQUIRED],
+				'pattern'				=> ['type' => API_REGEX, 'flags' => API_REQUIRED | API_NOT_EMPTY, 'length' => 255]
+			]],
+			'show_thumbnail'		=> ['type' => API_INT32, 'default' => 0, 'in' => '0,1'],
+			'aggregate_function'	=> ['type' => API_INT32, 'in' => implode(',', [AGGREGATE_NONE, AGGREGATE_MIN, AGGREGATE_MAX, AGGREGATE_AVG, AGGREGATE_COUNT, AGGREGATE_SUM, AGGREGATE_FIRST, AGGREGATE_LAST]), 'default' => AGGREGATE_NONE],
+			'time_period'			=> ['type' => API_ANY],
+			'history'				=> ['type' => API_MULTIPLE, 'rules' => [
+										['if' => ['field' => 'data', 'in' => self::DATA_ITEM_VALUE],
+											'type' => API_INT32, 'default' => self::HISTORY_DATA_AUTO, 'in' => implode(',', [self::HISTORY_DATA_AUTO, self::HISTORY_DATA_HISTORY, self::HISTORY_DATA_TRENDS])],
+										['else' => true,
+											'type' => API_INT32]
+			]]
+		]];
+
+		if (($this->getFlags() & self::FLAG_NOT_EMPTY) !== 0) {
+			self::setValidationRuleFlag($validation_rules, API_NOT_EMPTY);
+		}
+
+		return $validation_rules;
+	}
+}

--- a/includes/CWidgetFieldColumnsListView.php
+++ b/includes/CWidgetFieldColumnsListView.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2026 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere\Includes;
+
+use CButton,
+	CCol,
+	CColHeader,
+	CDiv,
+	CList,
+	CTable,
+	CTag,
+	CVar,
+	CWidgetFieldView;
+
+class CWidgetFieldColumnsListView extends CWidgetFieldView {
+
+	public function __construct(CWidgetFieldColumnsList $field) {
+		$this->field = $field;
+	}
+
+	public function getView(): CTag {
+		$columns = $this->field->getValue();
+
+		$header = [
+			'',
+			(new CColHeader(_('Name')))->addStyle('width: 39%'),
+			(new CColHeader(_('Data')))->addStyle('width: 59%'),
+			_('Actions')
+		];
+
+		$row_actions = [
+			(new CButton('edit', _('Edit')))
+				->addClass(ZBX_STYLE_BTN_LINK)
+				->removeId(),
+			(new CButton('remove', _('Remove')))
+				->addClass(ZBX_STYLE_BTN_LINK)
+				->removeId()
+		];
+
+		$view = (new CTable())
+			->setId('list_'.$this->field->getName())
+			->setHeader($header);
+
+		foreach ($columns as $column_index => $column) {
+			$column_data = [new CVar('sortorder['.$this->field->getName().'][]', $column_index)];
+
+			foreach ($column as $key => $value) {
+				$column_data[] = new CVar($this->field->getName().'['.$column_index.']['.$key.']', $value);
+			}
+
+			if ($column['data'] == CWidgetFieldColumnsList::DATA_HOST_NAME) {
+				$label = new CTag('em', true, _('Host name'));
+			}
+			elseif ($column['data'] == CWidgetFieldColumnsList::DATA_TEXT) {
+				$label = new CTag('em', true, $column['text']);
+			}
+			elseif (array_key_exists('item', $column)) {
+				$label = $column['item'];
+			}
+			else {
+				$label = '';
+			}
+
+			$view->addRow([
+				(new CCol((new CDiv)->addClass(ZBX_STYLE_DRAG_ICON)))->addClass(ZBX_STYLE_TD_DRAG_ICON),
+				(new CDiv($column['name']))->addClass('text'),
+				(new CDiv($label))->addClass('text'),
+				[
+					(new CList($row_actions))->addClass(ZBX_STYLE_HOR_LIST),
+					$column_data
+				]
+			]);
+		}
+
+		$view->addRow(
+			(new CCol(
+				(new CButton('add', _('Add')))
+					->addClass(ZBX_STYLE_BTN_LINK)
+					->setEnabled(!$this->isDisabled())
+			))->setColSpan(count($header))
+		);
+
+		return $view;
+	}
+}

--- a/includes/WidgetForm.php
+++ b/includes/WidgetForm.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+namespace Modules\TopHostsMonzphere\Includes;
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+use Modules\TopHostsMonzphere\Widget;
+
+use Zabbix\Widgets\{
+	CWidgetField,
+	CWidgetForm
+};
+
+use Zabbix\Widgets\Fields\{
+	CWidgetFieldCheckBox,
+	CWidgetFieldIntegerBox,
+	CWidgetFieldMultiSelectGroup,
+	CWidgetFieldMultiSelectHost,
+	CWidgetFieldMultiSelectOverrideHost,
+	CWidgetFieldRadioButtonList,
+	CWidgetFieldSelect,
+	CWidgetFieldTags
+};
+
+/**
+ * Top hosts data widget form.
+ */
+class WidgetForm extends CWidgetForm {
+
+	private const DEFAULT_HOSTS_COUNT = 10;
+	private const DEFAULT_ORDER_COLUMN = 0;
+
+	private array $field_column_values = [];
+
+	protected function normalizeValues(array $values): array {
+		$values = parent::normalizeValues($values);
+
+		if (array_key_exists('columnsthresholds', $values)) {
+			foreach ($values['columnsthresholds'] as $column_index => $fields) {
+				$values['columns'][$column_index]['thresholds'] = [];
+
+				foreach ($fields as $field_key => $field_values) {
+					foreach ($field_values as $value_index => $value) {
+						$values['columns'][$column_index]['thresholds'][$value_index][$field_key] = $value;
+					}
+				}
+			}
+		}
+
+		if (array_key_exists('sortorder', $values)) {
+			if (array_key_exists('column', $values) && array_key_exists('columns', $values['sortorder'])) {
+				$values['column'] = array_search($values['column'], $values['sortorder']['columns'], true);
+			}
+
+			foreach ($values['sortorder'] as $key => $sortorder) {
+				if (!array_key_exists($key, $values)) {
+					continue;
+				}
+
+				$sorted = [];
+
+				foreach ($sortorder as $index) {
+					$sorted[] = $values[$key][$index];
+				}
+
+				$values[$key] = $sorted;
+			}
+		}
+
+		if (array_key_exists('columns', $values)) {
+			foreach ($values['columns'] as $key => $value) {
+				$value['name'] = trim($value['name']);
+
+				switch ($value['data']) {
+					case CWidgetFieldColumnsList::DATA_ITEM_VALUE:
+						$this->field_column_values[$key] = $value['name'] === '' ? $value['item'] : $value['name'];
+						break;
+
+					case CWidgetFieldColumnsList::DATA_HOST_NAME:
+						$this->field_column_values[$key] = $value['name'] === '' ? _('Host name') : $value['name'];
+						break;
+
+					case CWidgetFieldColumnsList::DATA_TEXT:
+						$this->field_column_values[$key] = $value['name'] === '' ? $value['text'] : $value['name'];
+						break;
+				}
+			}
+		}
+
+		return $values;
+	}
+
+	public function addFields(): self {
+		return $this
+			->addField($this->isTemplateDashboard()
+				? null
+				: new CWidgetFieldMultiSelectGroup('groupids', _('Host groups'))
+			)
+			->addField($this->isTemplateDashboard()
+				? null
+				: new CWidgetFieldMultiSelectHost('hostids', _('Hosts'))
+			)
+			->addField($this->isTemplateDashboard()
+				? null
+				: (new CWidgetFieldRadioButtonList('evaltype', _('Host tags'), [
+					TAG_EVAL_TYPE_AND_OR => _('And/Or'),
+					TAG_EVAL_TYPE_OR => _('Or')
+				]))->setDefault(TAG_EVAL_TYPE_AND_OR)
+			)
+			->addField($this->isTemplateDashboard()
+				? null
+				: new CWidgetFieldTags('tags')
+			)
+			->addField(
+				new CWidgetFieldCheckBox('maintenance',
+					$this->isTemplateDashboard() ? _('Show data in maintenance') : _('Show hosts in maintenance')
+				)
+			)
+			->addField(
+				(new CWidgetFieldColumnsList('columns', _('Columns')))
+					->setFlags(CWidgetField::FLAG_NOT_EMPTY | CWidgetField::FLAG_LABEL_ASTERISK)
+			)
+			->addField(
+				(new CWidgetFieldSelect('column', _('Order by'), $this->field_column_values))
+					->setDefault($this->field_column_values
+						? self::DEFAULT_ORDER_COLUMN
+						: CWidgetFieldSelect::DEFAULT_VALUE
+					)
+					->setFlags(CWidgetField::FLAG_LABEL_ASTERISK)
+			)
+			->addField(
+				(new CWidgetFieldRadioButtonList('order', _('Order'), [
+					Widget::ORDER_TOP_N => _('Top N'),
+					Widget::ORDER_BOTTOM_N => _('Bottom N')
+				]))->setDefault(Widget::ORDER_TOP_N)
+			)
+			->addField($this->isTemplateDashboard()
+				? null
+				: (new CWidgetFieldIntegerBox('show_lines', _('Host limit'), ZBX_MIN_WIDGET_LINES,
+					ZBX_MAX_WIDGET_LINES
+				))
+					->setDefault(self::DEFAULT_HOSTS_COUNT)
+					->setFlags(CWidgetField::FLAG_LABEL_ASTERISK)
+			)
+			->addField(
+				new CWidgetFieldMultiSelectOverrideHost()
+			);
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,49 @@
+{
+	"manifest_version": 2.0,
+	"id": "tophostsmonzphere",
+	"type": "widget",
+	"name": "Top hosts Monzphere",
+	"namespace": "TopHostsMonzphere",
+	"version": "2.0",
+	"author": "Monzphere",
+	"description": "Displays top N hosts that have the highest or the lowest item value (for example, CPU load) with an option to add progress-bar visualizations, customize report columns, and sort by clicking column headers.",
+	"url": "monzphere.com",
+	"widget": {
+		"js_class": "CWidgetTopHostsMonzphere",
+		"size": {
+			"width": 12,
+			"height": 5
+		},
+		"refresh_rate": 60,
+		"in": {
+			"hostids": {
+				"type": "_hostids"
+			},
+			"groupids": {
+				"type": "_hostgroupids"
+			}
+		},
+		"out": [
+			{
+				"type": "_hostid"
+			},
+			{
+				"type": "_hostids"
+			}
+		]
+	},
+	"actions": {
+		"widget.tophostsmonzphere.view": {
+			"class": "WidgetViewMonzphere"
+		},
+		"widget.tophostsmonzphere.column.edit": {
+			"class": "ColumnEditMonzphere",
+			"view": "column.edit",
+			"layout": "layout.json"
+		}
+	},
+	"assets": {
+		"js": ["class.widgetmonzphere.js"],
+		"css": ["widget.monzphere.css"]
+	}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Setup script for TopHostMonzphere module on Zabbix 7.4
+# Run this script from the module directory: /usr/share/zabbix/ui/modules/TopHostMonzphere/
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NATIVE_TOPHOSTS="/usr/share/zabbix/ui/widgets/tophosts"
+
+echo "Setting up TopHostMonzphere for Zabbix 7.4..."
+
+# Check if native tophosts widget exists
+if [ ! -d "$NATIVE_TOPHOSTS" ]; then
+    echo "ERROR: Native tophosts widget not found at $NATIVE_TOPHOSTS"
+    exit 1
+fi
+
+# Copy required files from native tophosts widget
+echo "Copying CWidgetFieldColumnsList.php..."
+cp "$NATIVE_TOPHOSTS/includes/CWidgetFieldColumnsList.php" "$SCRIPT_DIR/includes/"
+
+echo "Copying CWidgetFieldColumnsListView.php..."
+cp "$NATIVE_TOPHOSTS/includes/CWidgetFieldColumnsListView.php" "$SCRIPT_DIR/includes/"
+
+# Update namespace in copied files
+echo "Updating namespaces..."
+sed -i 's/namespace Widgets\\TopHosts\\Includes;/namespace Modules\\TopHostsMonzphere\\Includes;/g' "$SCRIPT_DIR/includes/CWidgetFieldColumnsList.php"
+sed -i 's/namespace Widgets\\TopHosts\\Includes;/namespace Modules\\TopHostsMonzphere\\Includes;/g' "$SCRIPT_DIR/includes/CWidgetFieldColumnsListView.php"
+
+# Update any internal references to the Widget class
+sed -i 's/use Widgets\\TopHosts\\Widget;/use Modules\\TopHostsMonzphere\\Widget;/g' "$SCRIPT_DIR/includes/CWidgetFieldColumnsList.php"
+sed -i 's/use Widgets\\TopHosts\\Widget;/use Modules\\TopHostsMonzphere\\Widget;/g' "$SCRIPT_DIR/includes/CWidgetFieldColumnsListView.php"
+
+# Set correct ownership
+echo "Setting ownership..."
+chown -R www-data:www-data "$SCRIPT_DIR"
+
+echo "Setup complete! Restart PHP-FPM with: systemctl restart php*-fpm"

--- a/views/column.edit.js.php
+++ b/views/column.edit.js.php
@@ -1,0 +1,298 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+
+?>
+
+window.tophosts_column_edit_form = new class {
+
+	#overlay;
+	#dialogue;
+	#form;
+	#thresholds_table;
+	#highlights_table;
+
+	init({form_id, thresholds, highlights, thresholds_colors}) {
+		this.#form = document.getElementById(form_id);
+		this.#overlay = overlays_stack.getById('tophostsmonzphere-column-edit-overlay');
+		this.#dialogue = this.#overlay.$dialogue[0];
+
+		this.#thresholds_table = document.getElementById('thresholds_table');
+		this.#highlights_table = document.getElementById('highlights_table');
+
+		// Attach event listeners.
+		for (const element_name of ['data', 'display_value_as', 'display', 'aggregate_function', 'history']) {
+			const element = this.#form.querySelector(`[name="${element_name}"]`);
+			if (element) {
+				if (element.tagName === 'Z-SELECT') {
+					element.addEventListener('change', () => this.#updateForm());
+				}
+				else {
+					for (const radio of this.#form.querySelectorAll(`[name="${element_name}"]`)) {
+						radio.addEventListener('change', () => this.#updateForm());
+					}
+				}
+			}
+		}
+
+		colorPalette.setThemeColors(thresholds_colors);
+
+		// Initialize thresholds table.
+		this.#thresholds_table.addEventListener('afteradd.dynamicRows', e => {
+			const $colorpicker = $('tr.form_row:last input[name$="[color]"]', e.target);
+			$colorpicker.colorpicker({appendTo: $colorpicker.closest('.input-color-picker')});
+			this.#updateForm();
+		});
+		this.#thresholds_table.addEventListener('afterremove.dynamicRows', () => this.#updateForm());
+
+		$(this.#thresholds_table).dynamicRows({
+			rows: thresholds,
+			template: '#thresholds-row-tmpl',
+			allow_empty: true,
+			dataCallback: (row_data) => {
+				if (!('color' in row_data)) {
+					row_data.color = this.#getNextColor();
+				}
+			}
+		});
+
+		$('tr.form_row input[name$="[color]"]', this.#thresholds_table).each((i, colorpicker) => {
+			$(colorpicker).colorpicker({appendTo: $(colorpicker).closest('.input-color-picker')});
+		});
+
+		// Initialize highlights table.
+		this.#highlights_table.addEventListener('afteradd.dynamicRows', e => {
+			const $colorpicker = $('tr.form_row:last input[name$="[color]"]', e.target);
+			$colorpicker.colorpicker({appendTo: $colorpicker.closest('.input-color-picker')});
+			this.#updateForm();
+		});
+		this.#highlights_table.addEventListener('afterremove.dynamicRows', () => this.#updateForm());
+
+		$(this.#highlights_table).dynamicRows({
+			rows: highlights,
+			template: '#highlights-row-tmpl',
+			allow_empty: true,
+			dataCallback: (row_data) => {
+				if (!('color' in row_data)) {
+					row_data.color = this.#getNextColor();
+				}
+			}
+		});
+
+		$('tr.form_row input[name$="[color]"]', this.#highlights_table).each((i, colorpicker) => {
+			$(colorpicker).colorpicker({appendTo: $(colorpicker).closest('.input-color-picker')});
+		});
+
+		// Trim values on change.
+		this.#form.addEventListener('change', (e) => {
+			if (e.target.value) {
+				e.target.value = e.target.value.trim();
+			}
+		}, {capture: true});
+
+		// Initialize form elements accessibility.
+		this.#updateForm();
+
+		this.#form.style.display = '';
+		this.#form.querySelector('[name="name"]').focus();
+	}
+
+	#getNextColor() {
+		const colors = this.#form.querySelectorAll('.input-color-picker input');
+		const used_colors = [];
+
+		for (const color of colors) {
+			if (color.value !== '') {
+				used_colors.push(color.value);
+			}
+		}
+
+		return colorPalette.getNextColor(used_colors);
+	}
+
+	#updateForm() {
+		const data = this.#form.querySelector('[name="data"]').value;
+		const data_item_value = (data == <?= CWidgetFieldColumnsList::DATA_ITEM_VALUE ?>);
+		const data_text = (data == <?= CWidgetFieldColumnsList::DATA_TEXT ?>);
+		const data_host_name = (data == <?= CWidgetFieldColumnsList::DATA_HOST_NAME ?>);
+
+		const display_value_as_el = this.#form.querySelector('[name="display_value_as"]:checked');
+		const display_value_as = display_value_as_el ? parseInt(display_value_as_el.value) : <?= CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC ?>;
+		const display_value_as_numeric = (display_value_as == <?= CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC ?>);
+		const display_value_as_binary = (display_value_as == <?= CWidgetFieldColumnsList::DISPLAY_VALUE_AS_BINARY ?>);
+
+		const display_el = this.#form.querySelector('[name="display"]:checked');
+		const display = display_el ? parseInt(display_el.value) : <?= CWidgetFieldColumnsList::DISPLAY_AS_IS ?>;
+		const display_as_is = (display == <?= CWidgetFieldColumnsList::DISPLAY_AS_IS ?>);
+		const display_sparkline = (display == <?= CWidgetFieldColumnsList::DISPLAY_SPARKLINE ?>);
+
+		const aggregate_function = parseInt(this.#form.querySelector('[name="aggregate_function"]').value);
+		const aggregate_none = (aggregate_function == <?= AGGREGATE_NONE ?>);
+
+		const history_el = this.#form.querySelector('[name="history"]:checked');
+		const history_trends = history_el && (parseInt(history_el.value) == <?= CWidgetFieldColumnsList::HISTORY_DATA_TRENDS ?>);
+
+		// Item name field.
+		for (const element of this.#form.querySelectorAll('.js-item-row')) {
+			element.style.display = data_item_value ? '' : 'none';
+		}
+		$('#item').multiSelect(data_item_value ? 'enable' : 'disable');
+
+		// Text field.
+		for (const element of this.#form.querySelectorAll('.js-text-row')) {
+			element.style.display = data_text ? '' : 'none';
+		}
+
+		// Display value as field.
+		for (const element of this.#form.querySelectorAll('.js-display-value-as-row')) {
+			element.style.display = data_item_value ? '' : 'none';
+		}
+
+		// Show thumbnail field.
+		const show_thumbnail_visible = data_item_value && display_value_as_binary;
+		for (const element of this.#form.querySelectorAll('.js-show-thumbnail-row')) {
+			element.style.display = show_thumbnail_visible ? '' : 'none';
+		}
+
+		// Display field.
+		const display_visible = data_item_value && display_value_as_numeric;
+		for (const element of this.#form.querySelectorAll('.js-display-row')) {
+			element.style.display = display_visible ? '' : 'none';
+		}
+
+		// Min/Max fields.
+		const min_max_visible = data_item_value && display_value_as_numeric && !display_as_is && !display_sparkline;
+		for (const element of this.#form.querySelectorAll('.js-min-row, .js-max-row')) {
+			element.style.display = min_max_visible ? '' : 'none';
+		}
+
+		// Sparkline configuration.
+		for (const element of this.#form.querySelectorAll('.js-sparkline-row')) {
+			element.style.display = (data_item_value && display_sparkline) ? '' : 'none';
+		}
+
+		// Base color field.
+		const base_color_visible = !data_host_name && (!data_item_value || !display_value_as_numeric || display_as_is);
+		for (const element of this.#form.querySelectorAll('.js-base-color-row')) {
+			element.style.display = base_color_visible ? '' : 'none';
+		}
+
+		// Thresholds table.
+		const thresholds_visible = data_item_value && display_value_as_numeric;
+		for (const element of this.#form.querySelectorAll('.js-thresholds-row')) {
+			element.style.display = thresholds_visible ? '' : 'none';
+		}
+
+		// Highlights table.
+		const highlights_visible = (data_item_value && !display_value_as_numeric) || data_text;
+		for (const element of this.#form.querySelectorAll('.js-highlights-row')) {
+			element.style.display = highlights_visible ? '' : 'none';
+		}
+
+		// Decimal places field.
+		const decimal_visible = data_item_value && display_value_as_numeric && !display_sparkline;
+		for (const element of this.#form.querySelectorAll('.js-decimal-places-row')) {
+			element.style.display = decimal_visible ? '' : 'none';
+		}
+
+		// Advanced configuration.
+		const advanced_config = document.getElementById('advanced_configuration');
+		if (advanced_config) {
+			advanced_config.style.display = data_item_value ? '' : 'none';
+		}
+
+		// Aggregate function field.
+		const aggregate_function_el = this.#form.querySelector('[name="aggregate_function"]');
+		if (aggregate_function_el) {
+			aggregate_function_el.disabled = !data_item_value;
+		}
+
+		// Time period field.
+		if (this.#form.fields && this.#form.fields.time_period) {
+			this.#form.fields.time_period.disabled = !data_item_value || aggregate_none;
+		}
+
+		// History data field.
+		for (const element of this.#form.querySelectorAll('[name="history"]')) {
+			element.disabled = !data_item_value;
+		}
+
+		// Warning icons.
+		const display_warning = document.getElementById('tophosts-column-display-warning');
+		if (display_warning) {
+			display_warning.style.display = (data_item_value && !display_as_is) ? '' : 'none';
+		}
+
+		const aggregate_warning = document.getElementById('tophosts-column-aggregate-function-warning');
+		if (aggregate_warning) {
+			const aggregate_warning_functions = [<?= AGGREGATE_AVG ?>, <?= AGGREGATE_MIN ?>, <?= AGGREGATE_MAX ?>, <?= AGGREGATE_SUM ?>];
+			aggregate_warning.style.display = (data_item_value && aggregate_warning_functions.includes(aggregate_function)) ? '' : 'none';
+		}
+
+		const history_warning = document.getElementById('tophosts-column-history-data-warning');
+		if (history_warning) {
+			history_warning.style.display = (data_item_value && history_trends) ? '' : 'none';
+		}
+	}
+
+	submit(overlay) {
+		this.#overlay.setLoading();
+
+		const curl = new Curl(this.#form.getAttribute('action'));
+		const fields = getFormFields(this.#form);
+
+		fetch(curl.getUrl(), {
+			method: 'POST',
+			headers: {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+			body: urlEncodeData(fields)
+		})
+			.then(response => response.json())
+			.then(response => {
+				if ('error' in response) {
+					throw {error: response.error};
+				}
+
+				overlayDialogueDestroy(overlay.dialogueid);
+
+				this.#dialogue.dispatchEvent(new CustomEvent('dialogue.submit', {detail: response}));
+			})
+			.catch((exception) => {
+				for (const element of this.#form.parentNode.children) {
+					if (element.matches('.msg-good, .msg-bad, .msg-warning')) {
+						element.parentNode.removeChild(element);
+					}
+				}
+
+				let title, messages;
+
+				if (typeof exception === 'object' && 'error' in exception) {
+					title = exception.error.title;
+					messages = exception.error.messages;
+				}
+				else {
+					messages = [<?= json_encode(_('Unexpected server error.')) ?>];
+				}
+
+				const message_box = makeMessageBox('bad', messages, title)[0];
+
+				this.#form.parentNode.insertBefore(message_box, this.#form);
+			})
+			.finally(() => {
+				this.#overlay.unsetLoading();
+			});
+	}
+};

--- a/views/column.edit.js.php
+++ b/views/column.edit.js.php
@@ -52,11 +52,7 @@ window.tophosts_column_edit_form = new class {
 		colorPalette.setThemeColors(thresholds_colors);
 
 		// Initialize thresholds table.
-		this.#thresholds_table.addEventListener('afteradd.dynamicRows', e => {
-			const $colorpicker = $('tr.form_row:last input[name$="[color]"]', e.target);
-			$colorpicker.colorpicker({appendTo: $colorpicker.closest('.input-color-picker')});
-			this.#updateForm();
-		});
+		this.#thresholds_table.addEventListener('afteradd.dynamicRows', () => this.#updateForm());
 		this.#thresholds_table.addEventListener('afterremove.dynamicRows', () => this.#updateForm());
 
 		$(this.#thresholds_table).dynamicRows({
@@ -70,16 +66,8 @@ window.tophosts_column_edit_form = new class {
 			}
 		});
 
-		$('tr.form_row input[name$="[color]"]', this.#thresholds_table).each((i, colorpicker) => {
-			$(colorpicker).colorpicker({appendTo: $(colorpicker).closest('.input-color-picker')});
-		});
-
 		// Initialize highlights table.
-		this.#highlights_table.addEventListener('afteradd.dynamicRows', e => {
-			const $colorpicker = $('tr.form_row:last input[name$="[color]"]', e.target);
-			$colorpicker.colorpicker({appendTo: $colorpicker.closest('.input-color-picker')});
-			this.#updateForm();
-		});
+		this.#highlights_table.addEventListener('afteradd.dynamicRows', () => this.#updateForm());
 		this.#highlights_table.addEventListener('afterremove.dynamicRows', () => this.#updateForm());
 
 		$(this.#highlights_table).dynamicRows({
@@ -91,10 +79,6 @@ window.tophosts_column_edit_form = new class {
 					row_data.color = this.#getNextColor();
 				}
 			}
-		});
-
-		$('tr.form_row input[name$="[color]"]', this.#highlights_table).each((i, colorpicker) => {
-			$(colorpicker).colorpicker({appendTo: $(colorpicker).closest('.input-color-picker')});
 		});
 
 		// Trim values on change.

--- a/views/column.edit.js.php
+++ b/views/column.edit.js.php
@@ -169,8 +169,8 @@ window.tophosts_column_edit_form = new class {
 			element.style.display = (data_item_value && display_sparkline) ? '' : 'none';
 		}
 
-		// Base color field.
-		const base_color_visible = !data_host_name && (!data_item_value || !display_value_as_numeric || display_as_is);
+		// Base color field - visible for all except host name and sparkline.
+		const base_color_visible = !data_host_name && !(data_item_value && display_sparkline);
 		for (const element of this.#form.querySelectorAll('.js-base-color-row')) {
 			element.style.display = base_color_visible ? '' : 'none';
 		}

--- a/views/column.edit.php
+++ b/views/column.edit.php
@@ -1,0 +1,413 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+/**
+ * @var CView $this
+ * @var array $data
+ */
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+
+$form = (new CForm())
+	->setId('tophosts_column_edit_form')
+	->setName('tophosts_column')
+	->addStyle('display: none;')
+	->addVar('action', $data['action'])
+	->addVar('update', 1);
+
+// Enable form submitting on Enter.
+$form->addItem((new CSubmitButton())->addClass(ZBX_STYLE_FORM_SUBMIT_HIDDEN));
+
+$form_grid = new CFormGrid();
+
+$scripts = [];
+
+if (array_key_exists('edit', $data)) {
+	$form->addVar('edit', 1);
+}
+
+// Name.
+$form_grid->addItem([
+	(new CLabel(_('Name'), 'column_name'))->setAsteriskMark(),
+	new CFormField(
+		(new CTextBox('name', $data['name'], false))
+			->setId('column_name')
+			->setWidth(ZBX_TEXTAREA_STANDARD_WIDTH)
+			->setAttribute('autofocus', 'autofocus')
+			->setAriaRequired()
+	)
+]);
+
+// Data.
+$form_grid->addItem([
+	new CLabel(_('Data'), 'data'),
+	new CFormField(
+		(new CSelect('data'))
+			->setValue($data['data'])
+			->addOptions(CSelect::createOptionsFromArray([
+				CWidgetFieldColumnsList::DATA_ITEM_VALUE => _('Item value'),
+				CWidgetFieldColumnsList::DATA_HOST_NAME => _('Host name'),
+				CWidgetFieldColumnsList::DATA_TEXT => _('Text')
+			]))
+			->setFocusableElementId('data')
+	)
+]);
+
+// Static text.
+$form_grid->addItem([
+	(new CLabel(_('Text'), 'text'))->setAsteriskMark()->addClass('js-text-row'),
+	(new CFormField(
+		(new CTextBox('text', $data['text']))
+			->setWidth(ZBX_TEXTAREA_STANDARD_WIDTH)
+			->setAttribute('placeholder', _('Text, supports {INVENTORY.*}, {HOST.*} macros'))
+	))->addClass('js-text-row')
+]);
+
+// Item.
+$parameters = [
+	'srctbl' => 'items',
+	'srcfld1' => 'name',
+	'dstfrm' => $form->getName(),
+	'dstfld1' => 'item',
+	'value_types' => [
+		ITEM_VALUE_TYPE_FLOAT,
+		ITEM_VALUE_TYPE_STR,
+		ITEM_VALUE_TYPE_LOG,
+		ITEM_VALUE_TYPE_UINT64,
+		ITEM_VALUE_TYPE_TEXT,
+		ITEM_VALUE_TYPE_BINARY
+	]
+];
+
+if ($data['templateid'] === '') {
+	$parameters['real_hosts'] = 1;
+	$parameters['resolve_macros'] = 1;
+}
+else {
+	$parameters += [
+		'hostid' => $data['templateid'],
+		'hide_host_filter' => true
+	];
+}
+
+$item_select = (new CPatternSelect([
+	'name' => 'item',
+	'object_name' => 'items',
+	'data' => $data['item'] === '' ? [] : [$data['item']],
+	'multiple' => false,
+	'popup' => [
+		'parameters' => $parameters
+	],
+	'add_post_js' => false
+]))->setWidth(ZBX_TEXTAREA_STANDARD_WIDTH);
+
+$scripts[] = $item_select->getPostJS();
+
+$form_grid->addItem([
+	(new CLabel(_('Item name'), 'item_ms'))->setAsteriskMark()->addClass('js-item-row'),
+	(new CFormField($item_select))->addClass('js-item-row')
+]);
+
+// Display value as.
+$form_grid->addItem([
+	(new CLabel(_('Display value as'), 'display_value_as'))->addClass('js-display-value-as-row'),
+	(new CFormField(
+		(new CRadioButtonList('display_value_as', (int) ($data['display_value_as'] ?? CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC)))
+			->addValue(_('Numeric'), CWidgetFieldColumnsList::DISPLAY_VALUE_AS_NUMERIC)
+			->addValue(_('Text'), CWidgetFieldColumnsList::DISPLAY_VALUE_AS_TEXT)
+			->addValue(_('Binary'), CWidgetFieldColumnsList::DISPLAY_VALUE_AS_BINARY)
+			->setModern()
+	))->addClass('js-display-value-as-row')
+]);
+
+// Show thumbnail.
+$form_grid->addItem([
+	(new CLabel(_('Show thumbnail'), 'show_thumbnail'))->addClass('js-show-thumbnail-row'),
+	(new CFormField(
+		(new CCheckBox('show_thumbnail'))
+			->setChecked($data['show_thumbnail'] ?? false)
+	))->addClass('js-show-thumbnail-row')
+]);
+
+// Display.
+$form_grid->addItem([
+	(new CLabel(
+		[
+			_('Display'),
+			(makeWarningIcon(_('With this setting only numeric data will be displayed.')))
+				->setId('tophosts-column-display-warning')
+		],
+		'display'
+	))->addClass('js-display-row'),
+	(new CFormField(
+		(new CRadioButtonList('display', (int) $data['display']))
+			->addValue(_('As is'), CWidgetFieldColumnsList::DISPLAY_AS_IS)
+			->addValue(_('Bar'), CWidgetFieldColumnsList::DISPLAY_BAR)
+			->addValue(_('Indicators'), CWidgetFieldColumnsList::DISPLAY_INDICATORS)
+			->addValue(_('Sparkline'), CWidgetFieldColumnsList::DISPLAY_SPARKLINE)
+			->setModern()
+	))->addClass('js-display-row')
+]);
+
+// Min value.
+$form_grid->addItem([
+	(new CLabel(_('Min'), 'min'))->addClass('js-min-row'),
+	(new CFormField(
+		(new CTextBox('min', $data['min']))
+			->setWidth(ZBX_TEXTAREA_FILTER_SMALL_WIDTH)
+			->setAttribute('placeholder', _('calculated'))
+	))->addClass('js-min-row')
+]);
+
+// Max value.
+$form_grid->addItem([
+	(new CLabel(_('Max'), 'max'))->addClass('js-max-row'),
+	(new CFormField(
+		(new CTextBox('max', $data['max']))
+			->setWidth(ZBX_TEXTAREA_FILTER_SMALL_WIDTH)
+			->setAttribute('placeholder', _('calculated'))
+	))->addClass('js-max-row')
+]);
+
+// Sparkline configuration.
+if (array_key_exists('sparkline_field', $data)) {
+	$sparkline = (new CWidgetFieldSparklineView($data['sparkline_field']))
+		->setFormName($form->getName());
+
+	foreach ($sparkline->getViewCollection() as ['label' => $label, 'view' => $view, 'class' => $class]) {
+		$form_grid->addItem([
+			$label,
+			(new CFormField($view))->addClass($class)
+		]);
+	}
+
+	$scripts[] = $sparkline->getJavaScript();
+}
+
+// Base color.
+$form_grid->addItem([
+	(new CLabel(_('Base color'), 'lbl_base_color'))->addClass('js-base-color-row'),
+	(new CFormField(
+		(new CColorPicker('base_color'))
+			->setColor($data['base_color'])
+			->allowEmpty()
+	))->addClass('js-base-color-row')
+]);
+
+// Thresholds table.
+$threshold_header_row = [
+	'',
+	(new CColHeader(_('Threshold')))->setWidth('100%'),
+	_('Action')
+];
+
+$thresholds = (new CDiv(
+	(new CTable())
+		->setId('thresholds_table')
+		->addClass(ZBX_STYLE_TABLE_FORMS)
+		->setHeader($threshold_header_row)
+		->setFooter(new CRow(
+			(new CCol(
+				(new CButtonLink(_('Add')))->addClass('element-table-add')
+			))->setColSpan(count($threshold_header_row))
+		))
+))
+	->addClass('table-forms-separator')
+	->setWidth(ZBX_TEXTAREA_STANDARD_WIDTH);
+
+$thresholds->addItem(
+	(new CTemplateTag('thresholds-row-tmpl'))
+		->addItem((new CRow([
+			(new CColorPicker('thresholds[#{rowNum}][color]'))
+				->setColor('#{color}')
+				->allowEmpty(),
+			(new CTextBox('thresholds[#{rowNum}][threshold]', '#{threshold}', false))
+				->setWidth(ZBX_TEXTAREA_SMALL_WIDTH)
+				->setAriaRequired(),
+			(new CButton('thresholds[#{rowNum}][remove]', _('Remove')))
+				->addClass(ZBX_STYLE_BTN_LINK)
+				->addClass('element-table-remove')
+		]))->addClass('form_row'))
+);
+
+$form_grid->addItem([
+	(new CLabel([
+		_('Thresholds'),
+		makeWarningIcon(_('This setting applies only to numeric data.'))
+	], 'thresholds_table'))->addClass('js-thresholds-row'),
+	(new CFormField($thresholds))->addClass('js-thresholds-row')
+]);
+
+// Highlights table.
+$highlight_header_row = [
+	'',
+	(new CColHeader(_('Regular expression')))->setWidth('100%'),
+	_('Action')
+];
+
+$highlights = (new CDiv(
+	(new CTable())
+		->setId('highlights_table')
+		->addClass(ZBX_STYLE_TABLE_FORMS)
+		->setHeader($highlight_header_row)
+		->setFooter(new CRow(
+			(new CCol(
+				(new CButtonLink(_('Add')))->addClass('element-table-add')
+			))->setColSpan(count($highlight_header_row))
+		))
+))
+	->addClass('table-forms-separator')
+	->setWidth(ZBX_TEXTAREA_STANDARD_WIDTH);
+
+$highlights->addItem(
+	(new CTemplateTag('highlights-row-tmpl'))
+		->addItem((new CRow([
+			(new CColorPicker('highlights[#{rowNum}][color]'))
+				->setColor('#{color}')
+				->allowEmpty(),
+			(new CTextBox('highlights[#{rowNum}][pattern]', '#{pattern}', false))
+				->setWidth(ZBX_TEXTAREA_MEDIUM_WIDTH)
+				->setAriaRequired(),
+			(new CButton('highlights[#{rowNum}][remove]', _('Remove')))
+				->addClass(ZBX_STYLE_BTN_LINK)
+				->addClass('element-table-remove')
+		]))->addClass('form_row'))
+);
+
+$form_grid->addItem([
+	(new CLabel([
+		_('Highlights'),
+		makeWarningIcon(_('This setting applies only to text data.'))
+	], 'highlights_table'))->addClass('js-highlights-row'),
+	(new CFormField($highlights))->addClass('js-highlights-row')
+]);
+
+// Decimal places.
+$form_grid->addItem([
+	(new CLabel(_('Decimal places'), 'decimal_places'))->addClass('js-decimal-places-row'),
+	(new CFormField(
+		(new CNumericBox('decimal_places', $data['decimal_places'], 2))->setWidth(ZBX_TEXTAREA_NUMERIC_STANDARD_WIDTH)
+	))->addClass('js-decimal-places-row')
+]);
+
+// Advanced configuration fieldset.
+$advanced_config = (new CFormFieldsetCollapsible(_('Advanced configuration')))
+	->setId('advanced_configuration');
+
+// Aggregation function.
+$advanced_config->addItem([
+	new CLabel(
+		[
+			_('Aggregation function'),
+			(makeWarningIcon(_('With this setting only numeric items will be displayed.')))
+				->setId('tophosts-column-aggregate-function-warning')
+		],
+		'column_aggregate_function'
+	),
+	new CFormField(
+		(new CSelect('aggregate_function'))
+			->setId('aggregate_function')
+			->setValue($data['aggregate_function'])
+			->addOptions(CSelect::createOptionsFromArray([
+				AGGREGATE_NONE => CItemHelper::getAggregateFunctionName(AGGREGATE_NONE),
+				AGGREGATE_MIN => CItemHelper::getAggregateFunctionName(AGGREGATE_MIN),
+				AGGREGATE_MAX => CItemHelper::getAggregateFunctionName(AGGREGATE_MAX),
+				AGGREGATE_AVG => CItemHelper::getAggregateFunctionName(AGGREGATE_AVG),
+				AGGREGATE_COUNT => CItemHelper::getAggregateFunctionName(AGGREGATE_COUNT),
+				AGGREGATE_SUM => CItemHelper::getAggregateFunctionName(AGGREGATE_SUM),
+				AGGREGATE_FIRST => CItemHelper::getAggregateFunctionName(AGGREGATE_FIRST),
+				AGGREGATE_LAST => CItemHelper::getAggregateFunctionName(AGGREGATE_LAST)
+			]))
+			->setFocusableElementId('column_aggregate_function')
+	)
+]);
+
+// Time period.
+$time_period_field_view = (new CWidgetFieldTimePeriodView($data['time_period_field']))
+	->setDateFormat(ZBX_FULL_DATE_TIME)
+	->setFromPlaceholder(_('YYYY-MM-DD hh:mm:ss'))
+	->setToPlaceholder(_('YYYY-MM-DD hh:mm:ss'))
+	->setFormName('tophosts_column');
+
+foreach ($time_period_field_view->getViewCollection() as ['label' => $label, 'view' => $view, 'class' => $class]) {
+	$advanced_config->addItem([
+		$label,
+		(new CFormField($view))->addClass($class)
+	]);
+}
+
+$scripts[] = $time_period_field_view->getJavaScript();
+
+// History data.
+$advanced_config->addItem([
+	new CLabel(
+		[
+			_('History data'),
+			(makeWarningIcon(
+				_('This setting applies only to numeric data. Non-numeric data will always be taken from history.')
+			))->setId('tophosts-column-history-data-warning')
+		],
+		'history'
+	),
+	new CFormField(
+		(new CRadioButtonList('history', (int) $data['history']))
+			->addValue(_('Auto'), CWidgetFieldColumnsList::HISTORY_DATA_AUTO)
+			->addValue(_('History'), CWidgetFieldColumnsList::HISTORY_DATA_HISTORY)
+			->addValue(_('Trends'), CWidgetFieldColumnsList::HISTORY_DATA_TRENDS)
+			->setModern()
+	)
+]);
+
+$form_grid->addItem($advanced_config);
+
+$form_grid->addItem(new CScriptTag([
+	'document.forms.tophosts_column.fields = {};',
+	$time_period_field_view->getJavaScript()
+]));
+
+$form
+	->addItem($form_grid)
+	->addItem(
+		(new CScriptTag('
+			tophosts_column_edit_form.init('.json_encode([
+				'form_id' => $form->getId(),
+				'thresholds' => $data['thresholds'],
+				'highlights' => $data['highlights'] ?? [],
+				'thresholds_colors' => $data['thresholds_colors']
+			], JSON_THROW_ON_ERROR).');
+		'))->setOnDocumentReady()
+	);
+
+$output = [
+	'header'		=> array_key_exists('edit', $data) ? _('Update column') : _('New column'),
+	'script_inline'	=> implode('', $scripts).$this->readJsFile('column.edit.js.php', null, ''),
+	'body'			=> $form->toString(),
+	'buttons'		=> [
+		[
+			'title'		=> array_key_exists('edit', $data) ? _('Update') : _('Add'),
+			'keepOpen'	=> true,
+			'isSubmit'	=> true,
+			'action'	=> 'tophosts_column_edit_form.submit(overlay)'
+		]
+	]
+];
+
+if ($data['user']['debug_mode'] == GROUP_DEBUG_MODE_ENABLED) {
+	CProfiler::getInstance()->stop();
+	$output['debug'] = CProfiler::getInstance()->make()->toString();
+}
+
+echo json_encode($output, JSON_THROW_ON_ERROR);

--- a/views/widget.edit.js.php
+++ b/views/widget.edit.js.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+?>
+
+
+window.widget_form = new class extends CWidgetForm {
+
+	#form;
+	#list_columns;
+	#templateid;
+	#column_index;
+
+	init({templateid}) {
+		this.#form = this.getForm();
+		this.#templateid = templateid;
+
+		this.#list_columns = document.getElementById('list_columns');
+
+		new CSortable(this.#list_columns.querySelector('tbody'), {
+			selector_handle: 'div.<?= ZBX_STYLE_DRAG_ICON ?>',
+			freeze_end: 1
+		});
+
+		this.#list_columns.addEventListener('click', (e) => this.#processColumnsAction(e));
+	}
+
+	#processColumnsAction(e) {
+		const target = e.target;
+
+		let column_popup;
+
+		switch (target.getAttribute('name')) {
+			case 'add':
+				this.#column_index = this.#list_columns.querySelectorAll('tr').length;
+
+				column_popup = PopUp(
+					'widget.tophostsmonzphere.column.edit',
+					{templateid: this.#templateid},
+					{
+						dialogueid: 'tophostsmonzphere-column-edit-overlay',
+						dialogue_class: 'modal-popup-generic'
+					}
+				).$dialogue[0];
+				column_popup.addEventListener('dialogue.submit', (e) => this.#updateColumns(e));
+				column_popup.addEventListener('dialogue.close', this.#removeColorpicker);
+				break;
+
+			case 'edit':
+				const form_fields = getFormFields(this.#form);
+
+				this.#column_index = target.closest('tr').querySelector('[name="sortorder[columns][]"]').value;
+
+				column_popup = PopUp(
+					'widget.tophostsmonzphere.column.edit',
+					{...form_fields.columns[this.#column_index], edit: 1, templateid: this.#templateid},
+					{
+						dialogueid: 'tophostsmonzphere-column-edit-overlay',
+						dialogue_class: 'modal-popup-generic'
+					}
+				).$dialogue[0];
+				column_popup.addEventListener('dialogue.submit', (e) => this.#updateColumns(e));
+				column_popup.addEventListener('dialogue.close', this.#removeColorpicker);
+				break;
+
+			case 'remove':
+				target.closest('tr').remove();
+				this.reload();
+				break;
+		}
+	}
+
+	#updateColumns(e) {
+		const data = e.detail;
+
+		if (data.edit) {
+			this.#form.querySelectorAll(`[name^="columns[${this.#column_index}][`)
+				.forEach((node) => node.remove());
+
+			delete data.edit;
+		}
+		else {
+			this.#addVar(`sortorder[columns][]`, this.#column_index);
+		}
+
+		if (data.thresholds) {
+			for (const [key, value] of Object.entries(data.thresholds)) {
+				this.#addVar(`columns[${this.#column_index}][thresholds][${key}][color]`, value.color);
+				this.#addVar(`columns[${this.#column_index}][thresholds][${key}][threshold]`, value.threshold);
+			}
+
+			delete data.thresholds;
+		}
+
+		if (data.highlights) {
+			for (const [key, value] of Object.entries(data.highlights)) {
+				this.#addVar(`columns[${this.#column_index}][highlights][${key}][color]`, value.color);
+				this.#addVar(`columns[${this.#column_index}][highlights][${key}][pattern]`, value.pattern);
+			}
+
+			delete data.highlights;
+		}
+
+		if (data.time_period) {
+			for (const [key, value] of Object.entries(data.time_period)) {
+				this.#addVar(`columns[${this.#column_index}][time_period][${key}]`, value);
+			}
+
+			delete data.time_period;
+		}
+
+		if (data.sparkline) {
+			for (const [key, value] of Object.entries(data.sparkline)) {
+				if (typeof value === 'object' && value !== null) {
+					for (const [subkey, subvalue] of Object.entries(value)) {
+						this.#addVar(`columns[${this.#column_index}][sparkline][${key}][${subkey}]`, subvalue);
+					}
+				}
+				else {
+					this.#addVar(`columns[${this.#column_index}][sparkline][${key}]`, value);
+				}
+			}
+
+			delete data.sparkline;
+		}
+
+		for (const [key, value] of Object.entries(data)) {
+			this.#addVar(`columns[${this.#column_index}][${key}]`, value);
+		}
+
+		this.reload();
+	}
+
+	#addVar(name, value) {
+		const input = document.createElement('input');
+		input.setAttribute('type', 'hidden');
+		input.setAttribute('name', name);
+		input.setAttribute('value', value);
+		this.#form.appendChild(input);
+	}
+
+	// Need to remove function after sub-popups auto close.
+	#removeColorpicker() {
+		$('#color_picker').hide();
+	}
+};

--- a/views/widget.edit.php
+++ b/views/widget.edit.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+/**
+ * Top hosts widget form view.
+ *
+ * @var CView $this
+ * @var array $data
+ */
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsListView;
+
+$form = new CWidgetFormView($data);
+
+$groupids = array_key_exists('groupids', $data['fields'])
+	? new CWidgetFieldMultiSelectGroupView($data['fields']['groupids'])
+	: null;
+
+$column = new CWidgetFieldSelectView($data['fields']['column']);
+
+if ($data['fields']['column']->getValues()) {
+	$form->registerField($column);
+	$column_view = $column->getView();
+}
+else {
+	$column_view = _('Add a column');
+}
+
+$form
+	->addField($groupids)
+	->addField(array_key_exists('hostids', $data['fields'])
+		? (new CWidgetFieldMultiSelectHostView($data['fields']['hostids']))
+			->setFilterPreselect([
+				'id' => $groupids->getId(),
+				'accept' => CMultiSelect::FILTER_PRESELECT_ACCEPT_ID,
+				'submit_as' => 'groupid'
+			])
+		: null
+	)
+	->addField(array_key_exists('evaltype', $data['fields'])
+		? new CWidgetFieldRadioButtonListView($data['fields']['evaltype'])
+		: null
+	)
+	->addField(array_key_exists('tags', $data['fields'])
+		? new CWidgetFieldTagsView($data['fields']['tags'])
+		: null
+	)
+	->addField(
+		new CWidgetFieldCheckBoxView($data['fields']['maintenance'])
+	)
+	->addField(
+		(new CWidgetFieldColumnsListView($data['fields']['columns']))->addClass(ZBX_STYLE_TABLE_FORMS_SEPARATOR)
+	)
+	->addItem([
+		$column->getLabel(),
+		(new CFormField($column_view))->addClass($column->isDisabled() ? ZBX_STYLE_DISABLED : null)
+	])
+	->addField(
+		new CWidgetFieldRadioButtonListView($data['fields']['order'])
+	)
+	->addField(array_key_exists('show_lines', $data['fields'])
+		? new CWidgetFieldIntegerBoxView($data['fields']['show_lines'])
+		: null
+	)
+	->includeJsFile('widget.edit.js.php')
+	->initFormJs('widget_form.init('.json_encode([
+		'templateid' => $data['templateid']
+	], JSON_THROW_ON_ERROR).');')
+	->show();

--- a/views/widget.view.php
+++ b/views/widget.view.php
@@ -1,0 +1,207 @@
+<?php declare(strict_types = 0);
+/*
+** Copyright (C) 2001-2024 Zabbix SIA
+**
+** This program is free software: you can redistribute it and/or modify it under the terms of
+** the GNU Affero General Public License as published by the Free Software Foundation, version 3.
+**
+** This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+** without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU Affero General Public License for more details.
+**
+** You should have received a copy of the GNU Affero General Public License along with this program.
+** If not, see <https://www.gnu.org/licenses/>.
+**/
+
+
+/**
+ * Top hosts widget view.
+ *
+ * @var CView $this
+ * @var array $data
+ */
+
+use Modules\TopHostsMonzphere\Widget;
+
+use Modules\TopHostsMonzphere\Includes\CWidgetFieldColumnsList;
+
+$table = new CTableInfo();
+
+if ($data['error'] !== null) {
+	$table->setNoDataMessage($data['error']);
+}
+else {
+	$header = [];
+
+	foreach ($data['configuration'] as $column_index => $column_config) {
+		if ($column_config['data'] == CWidgetFieldColumnsList::DATA_ITEM_VALUE) {
+			if ($column_config['display'] == CWidgetFieldColumnsList::DISPLAY_AS_IS) {
+				$header[] = (new CColHeader($column_config['name']))
+					->addClass(ZBX_STYLE_CENTER)
+					->addClass('sortable-monzphere')
+					->setAttribute('data-column', $column_index);
+			}
+			else {
+				$header[] = (new CColHeader($column_config['name']))
+					->setColSpan(2)
+					->addClass('sortable-monzphere')
+					->setAttribute('data-column', $column_index);
+			}
+		}
+		else {
+			$header[] = (new CColHeader($column_config['name']))
+				->addClass('sortable-monzphere')
+				->setAttribute('data-column', $column_index);
+		}
+	}
+
+	$table->setHeader($header);
+
+	foreach ($data['rows'] as ['columns' => $columns, 'context' => $context]) {
+		$row = [];
+
+		foreach ($columns as $i => $column) {
+			$column_config = $data['configuration'][$i];
+
+			if ($column === null) {
+				if ($column_config['data'] == CWidgetFieldColumnsList::DATA_ITEM_VALUE
+						&& $column_config['display'] != CWidgetFieldColumnsList::DISPLAY_AS_IS) {
+					$row[] = (new CCol(''))->setColSpan(2);
+				}
+				else {
+					$row[] = '';
+				}
+
+				continue;
+			}
+
+			$color = $column_config['base_color'];
+
+			if ($column_config['data'] == CWidgetFieldColumnsList::DATA_ITEM_VALUE
+					&& $column_config['display'] == CWidgetFieldColumnsList::DISPLAY_AS_IS
+					&& array_key_exists('thresholds', $column_config)) {
+				$is_numeric_data = in_array($column['item']['value_type'],
+					[ITEM_VALUE_TYPE_FLOAT, ITEM_VALUE_TYPE_UINT64]
+				) || CAggFunctionData::isNumericResult($column_config['aggregate_function']);
+
+				if ($is_numeric_data) {
+					foreach ($column_config['thresholds'] as $threshold) {
+						$threshold_value = $column['is_binary_units']
+							? $threshold['threshold_binary']
+							: $threshold['threshold'];
+
+						if ($column['value'] < $threshold_value) {
+							break;
+						}
+
+						$color = $threshold['color'];
+					}
+				}
+			}
+
+			switch ($column_config['data']) {
+				case CWidgetFieldColumnsList::DATA_HOST_NAME:
+					$row[] = (new CCol(
+						(new CLinkAction($column['value']))->setMenuPopup(CMenuPopupHelper::getHost($column['hostid']))
+					))
+						->addStyle($color !== '' ? 'background-color: #' . $color : null)
+						->addItem($column['maintenance_status'] == HOST_MAINTENANCE_STATUS_ON
+							? makeMaintenanceIcon($column['maintenance_type'], $column['maintenance_name'],
+								$column['maintenance_description']
+							)
+							: null
+						);
+
+					break;
+
+				case CWidgetFieldColumnsList::DATA_TEXT:
+					$row[] = (new CCol($column['value']))
+						->addStyle($color !== '' ? 'background-color: #' . $color : null);
+
+					break;
+
+				case CWidgetFieldColumnsList::DATA_ITEM_VALUE:
+					if ($column['item']['value_type'] == ITEM_VALUE_TYPE_BINARY) {
+						$formatted_value = italic(_('binary value'))->addClass($color === '' ? ZBX_STYLE_GREY : null);
+						$column['value'] = _('binary value');
+					}
+					else {
+						$formatted_value = formatAggregatedHistoryValue($column['value'], $column['item'],
+							$column_config['aggregate_function'], false, true, [
+								'decimals' => $column_config['decimal_places'],
+								'decimals_exact' => true,
+								'small_scientific' => false,
+								'zero_as_zero' => false
+							]
+						);
+					}
+
+					if ($column_config['display'] == CWidgetFieldColumnsList::DISPLAY_AS_IS) {
+						$row[] = (new CCol())
+							->addStyle($color !== '' ? 'background-color: #' . $color : null)
+							->addItem(
+								(new CDiv($formatted_value))
+									->addClass(ZBX_STYLE_CENTER)
+									->addClass(ZBX_STYLE_CURSOR_POINTER)
+									->setHint(
+										(new CDiv($column['value']))->addClass(ZBX_STYLE_HINTBOX_WRAP)
+									)
+							);
+
+						break;
+					}
+
+					$bar_gauge = (new CBarGauge())
+						->setValue($column['value'])
+						->setAttribute('fill', $column_config['base_color'] !== ''
+							? '#' . $column_config['base_color']
+							: Widget::DEFAULT_FILL
+						)
+						->setAttribute('min', $column['is_binary_units']
+							? $column_config['min_binary']
+							: $column_config['min']
+						)
+						->setAttribute('max', $column['is_binary_units']
+							? $column_config['max_binary']
+							: $column_config['max']
+						);
+
+					if ($column_config['display'] == CWidgetFieldColumnsList::DISPLAY_BAR) {
+						$bar_gauge->setAttribute('solid', 1);
+					}
+
+					if (array_key_exists('thresholds', $column_config)) {
+						foreach ($column_config['thresholds'] as $threshold) {
+							$threshold_value = $column['is_binary_units']
+								? $threshold['threshold_binary']
+								: $threshold['threshold'];
+
+							$bar_gauge->addThreshold($threshold_value, '#'.$threshold['color']);
+						}
+					}
+
+					$row[] = new CCol($bar_gauge);
+					$row[] = (new CCol())
+						->addStyle('width: 0;')
+						->addItem(
+							(new CDiv($formatted_value))
+								->addClass(ZBX_STYLE_CURSOR_POINTER)
+								->addClass(ZBX_STYLE_NOWRAP)
+								->setHint(
+									(new CDiv($column['value']))->addClass(ZBX_STYLE_HINTBOX_WRAP)
+								)
+						);
+
+					break;
+			}
+		}
+
+		$table->addRow(
+			(new CRow($row))->setAttribute('data-hostid', $context['hostid'])
+		);
+	}
+}
+
+(new CWidgetView($data))
+	->addItem($table)
+	->show();


### PR DESCRIPTION
## Summary
- Updates the widget to be fully compatible with Zabbix 7.4.x
- Fixes breaking API changes in the Zabbix 7.4 widget framework

## Changes
- Added `CWidgetFieldColumnsList` and `CWidgetFieldColumnsListView` classes (now widget-local in 7.4)
- Updated `CColorPicker` API (uses `->setColor()` and `->allowEmpty()` instead of constructor params)
- Fixed widget form JS to extend `CWidgetForm` class
- Changed `ZABBIX.Dashboard.reloadWidgetProperties()` to `this.reload()`
- Added `dialogueid` parameter to PopUp() calls for overlay handling
- Updated form field visibility to use CSS class-based approach
- Added CSS for equal column width distribution

## Test plan
- [x] Tested on Zabbix 7.4.6
- [x] Widget displays correctly
- [x] Column sorting works
- [x] Add/Edit/Remove columns works
- [x] Thresholds and highlights work

🤖 Generated with [Claude Code](https://claude.ai/code)